### PR TITLE
Add spring-boot-starter-validation dependency to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
         <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
@@ -184,7 +188,6 @@
                             <basePackage>org.fybrik.datacatalog</basePackage>
                             <apiPackage>org.fybrik.datacatalog.api</apiPackage>
                             <modelPackage>org.fybrik.datacatalog.model</modelPackage>
-                            <!-- <invokerPackage>org.fybrik.datacatalog.handler</invokerPackage> -->
                             <configOptions>
                                 <!-- <delegatePattern>true</delegatePattern> -->
                                 <sourceFolder>src/main/gen</sourceFolder>
@@ -195,9 +198,6 @@
                                 <dateLibrary>java8-localdatetime</dateLibrary>
                                 <serializableModel>true</serializableModel>
                                 <dateLibrary>java8</dateLibrary>
-                                <!-- <configPackage>org.fybrik.datacatalog.config</configPackage> -->
-                                <!-- <generateSupportingFiles>true</generateSupportingFiles> -->
-                                <!-- <supportingFilesToGenerate> ApiUtil.java, GetPoliciesDecisionsApiController.java </supportingFilesToGenerate> -->
                                 <disallowAdditionalPropertiesIfNotPresent>true</disallowAdditionalPropertiesIfNotPresent>
                                 <generateModels>true</generateModels>
                                 <generateModelDocumentation>true</generateModelDocumentation>

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
         <!-- remove this dependency when spring update to use a new version of snake YAML -->
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
This PR adds `spring-boot-starter-validation` dependency to pom.xml. By doing so we get expected `"Bad Request"` when one of the required fields is missing from the request.